### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Rotary Encoder Half Step library for Arduino
 paragraph=This is a three speed Half Step Rotary Encoder library for Arduino with configurable sensitivity. Polled and interrupts are supported.
 category=Device Control
 url=https://github.com/Erriez/ErriezRotaryEncoderHalfStep
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format